### PR TITLE
enable TLS by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,12 +46,16 @@ Docker access can be verified by navigating to the nomad UI and looking into the
 
 # Accessing Nomad UI
 
-Nomad is accessiblity via the `SynologyIP:4646` port. Since acl is enabled you will need to
+Nomad is accessiblity via the `https://SynologyIP:4646` port. Since acl is enabled you will need to
 loging via ssh and run `nomad acl boostrap` to generate the initial token. You can then use the
 `SecretID` as token to authorize the UI portal or generate other tokens.
 
 ```bash
-$ nomad acl bootstrap
+$ NOMAD_CACERT=/volume1/nomad/etc/certs/nomad-ca.pem \
+  NOMAD_CLIENT_CERT=/volume1/nomad/etc/certs/server.pem \
+  NOMAD_CLIENT_KEY=/volume1/nomad/etc/certs/server-key.pem \
+  NOMAD_ADDR=https://localhost:4646 \
+  nomad acl bootstrap
 Accessor ID  = 5325e529-8048-2a6a-711e-8a1110562c93
 Secret ID    = fe672cf4-16b0-af1d-3db5-1832a8ec4c7d
 Name         = Bootstrap Token

--- a/build.sh
+++ b/build.sh
@@ -7,6 +7,9 @@ export ARCH="${ARCH:-amd64}"
 export NOMAD_VERSION="${NOMAD_VERSION:-1.4.3}"
 nomad_zip_file="nomad_${NOMAD_VERSION}_${OS}_${ARCH}.zip"
 export NOMAD_URL="${NOMAD_URL:-https://releases.hashicorp.com/nomad/${NOMAD_VERSION}/${nomad_zip_file}}"
+export CFSSL_VERSION="${CFSSL_VERSION:-1.6.3}"
+export CFSSL_URL=https://github.com/cloudflare/cfssl/releases/download/v${CFSSL_VERSION}/cfssl_${CFSSL_VERSION}_${OS}_${ARCH}
+export CFSSLJSON_URL=https://github.com/cloudflare/cfssl/releases/download/v${CFSSL_VERSION}/cfssljson_${CFSSL_VERSION}_${OS}_${ARCH}
 
 mkdir -p package
 
@@ -16,6 +19,14 @@ fi
 
 if [[ ! -f "./package/bin/nomad" ]]; then
     unzip -o -d "./package/bin/" "./tmp/${nomad_zip_file}"
+fi
+
+if [[ ! -f "./package/bin/cfssl" ]]; then
+    curl --create-dirs -Lo "./package/bin/cfssl" "${CFSSL_URL}"
+fi
+
+if [[ ! -f "./package/bin/cfssljson" ]]; then
+    curl --create-dirs -Lo "./package/bin/cfssljson" "${CFSSLJSON_URL}"
 fi
 
 ./info.sh "${PACKAGE_VERSION}" >> INFO

--- a/scripts/postinst
+++ b/scripts/postinst
@@ -8,8 +8,44 @@ cat <<EOF > "/var/packages/nomad/var/env.sh"
 export NOMAD_SHARE_DIR="$NOMAD_SHARE_DIR"
 EOF
 
+BINDIR=/var/packages/nomad/target/package/bin
+chmod +x ${BINDIR}/cfssljson
+chmod +x ${BINDIR}/cfssl
+
 mkdir -p "${NOMAD_SHARE_DIR}/etc/nomad.d"
 if [ ! -f "${NOMAD_SHARE_DIR}/etc/nomad.d/nomad.hcl" ]; then
+
+  # generate root cert
+  if [ ! -f "${NOMAD_SHARE_DIR}/etc/certs/nomad-ca-key.pem" ]; then
+    mkdir -p "$NOMAD_SHARE_DIR/etc/certs"
+
+    "$BINDIR/cfssl" print-defaults csr | "$BINDIR/cfssl" gencert -initca - | "$BINDIR/cfssljson" \
+      -bare "${NOMAD_SHARE_DIR}/etc/certs/nomad-ca"
+
+    if [ ! -f "${NOMAD_SHARE_DIR}/etc/certs/cfssl.json" ]; then
+  cat <<EOF > "${NOMAD_SHARE_DIR}/etc/certs/cfssl.json"
+{
+  "signing": {
+    "default": {
+      "expiry": "876666h",
+      "usages": ["signing", "key encipherment", "server auth", "client auth"]
+    }
+  }
+}
+EOF
+    fi
+
+    # generate cert for server
+    echo '{}' | "$BINDIR/cfssl" gencert -ca="$NOMAD_SHARE_DIR/etc/certs/nomad-ca.pem" \
+      -ca-key="$NOMAD_SHARE_DIR/etc/certs/nomad-ca-key.pem" -config="$NOMAD_SHARE_DIR/etc/certs/cfssl.json" \
+      -hostname="server.global.nomad,localhost,127.0.0.1" - | "$BINDIR/cfssljson" -bare "${NOMAD_SHARE_DIR}/etc/certs/server"
+
+    # generate cert for client
+    echo '{}' | "$BINDIR/cfssl" gencert -ca="$NOMAD_SHARE_DIR/etc/certs/nomad-ca.pem" \
+      -ca-key="$NOMAD_SHARE_DIR/etc/certs/nomad-ca-key.pem" -config="$NOMAD_SHARE_DIR/etc/certs/cfssl.json" \
+      -hostname="client.global.nomad,localhost,127.0.0.1" - | "$BINDIR/cfssljson" -bare "${NOMAD_SHARE_DIR}/etc/certs/client"
+  fi
+
   mkdir -p "${NOMAD_SHARE_DIR}/var/lib/nomad"
   cat <<EOF > "${NOMAD_SHARE_DIR}/etc/nomad.d/nomad.hcl"
 data_dir="${NOMAD_SHARE_DIR}/var/lib/nomad"
@@ -22,6 +58,17 @@ client {
 }
 acl {
   enabled = true
+}
+tls {
+  http = true
+  rpc  = true
+
+  ca_file   = "$NOMAD_SHARE_DIR/etc/certs/nomad-ca.pem"
+  cert_file = "$NOMAD_SHARE_DIR/etc/certs/server.pem"
+  key_file  = "$NOMAD_SHARE_DIR/etc/certs/server-key.pem"
+
+  verify_server_hostname = false
+  verify_https_client = true
 }
 plugin "raw_exec" {
   config {


### PR DESCRIPTION
Wait for next version of nomad to ship `nomad tls create` commands so we don't need to use `cfssl`. https://github.com/hashicorp/nomad/pull/14296

```bash
nomad tls ca create
nomad tls cert create -server / -client / - cli
nomad tls cert -info
```