### PR TITLE
fix: build script package version now syncs to nomad version

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 set -e
 
-export PACKAGE_VERSION=1.4.3-2000
+export NOMAD_VERSION="${NOMAD_VERSION:-1.4.4}"
+export PACKAGE_VERSION="${NOMAD_VERSION}-1000"
 export OS="${OS:-linux}"
 export ARCH="${ARCH:-amd64}"
-export NOMAD_VERSION="${NOMAD_VERSION:-1.4.3}"
 nomad_zip_file="nomad_${NOMAD_VERSION}_${OS}_${ARCH}.zip"
 export NOMAD_URL="${NOMAD_URL:-https://releases.hashicorp.com/nomad/${NOMAD_VERSION}/${nomad_zip_file}}"
 
@@ -14,11 +14,9 @@ if [[ ! -f "./tmp/${nomad_zip_file}" ]]; then
     curl --create-dirs -Lo "./tmp/$nomad_zip_file" "${NOMAD_URL}"
 fi
 
-if [[ ! -f "./package/bin/nomad" ]]; then
-    unzip -o -d "./package/bin/" "./tmp/${nomad_zip_file}"
-fi
+ unzip -o -d "./package/bin/" "./tmp/${nomad_zip_file}"
 
-./info.sh "${PACKAGE_VERSION}" >> INFO
+./info.sh "${PACKAGE_VERSION}" > INFO
 tar -cvzf package.tgz package
 tar -cvf package.spk INFO LICENSE conf/ package.tgz scripts/pre* scripts/post* scripts/start*
 rm package.tgz


### PR DESCRIPTION
The build script was not setup for multiple runs with different nomad versions. 

This PR fixes that problem by:

- Linking the Package Version to the Nomad Version, so you can see which version of nomad installed from the Synology Package manager.
- Not appending the INFO file but overwriting it with the new version. 
- Replaces the nomad binary file in the package directory every time.

With these changes you may now run NOMAD_VERSION=1.x.x and be sure the spk it generates contains the proper items, no matter how many different versions you choose to run.
