### PR TITLE
fix: replace Node.js 20 actions with native gh CLI commands

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,8 +18,6 @@ on:
 jobs:
   build:
     runs-on: ${{ matrix.os }}
-    outputs:
-      release_id: ${{ steps.release.outputs.id }}
     strategy:
       matrix:
         build: [linux]
@@ -55,12 +53,8 @@ jobs:
         echo "ASSET=$(ls *.spk)" >> $GITHUB_ENV
 
     - name: Create draft release and upload asset
-      id: release
-      uses: softprops/action-gh-release@v2
       if: startsWith(github.ref, 'refs/tags/')
-      with:
-        draft: true
-        files: ${{ env.ASSET }}
+      run: gh release create "${{ env.VERSION }}" --draft --title "${{ env.VERSION }}" "${{ env.ASSET }}"
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -71,8 +65,6 @@ jobs:
     needs: ['build']
     steps:
       - name: Publish release
-        uses: StuYarrow/publish-release@v1
+        run: gh release edit "${{ github.ref_name }}" --draft=false
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          id: ${{ needs.build.outputs.release_id }}


### PR DESCRIPTION
## Summary

Replace third-party GitHub Actions that use deprecated Node.js 20 runtime with native `gh` CLI commands.

## Changes

- **`softprops/action-gh-release@v2`** → `gh release create` (was using Node.js 20)
- **`StuYarrow/publish-release@v1`** → `gh release edit` (was using Node.js 16)
- Removed now-unused `release_id` job output

The `gh` CLI is pre-installed on GitHub runners and has no Node.js version dependency, eliminating the deprecation warnings before the June 2026 forced migration to Node.js 24.